### PR TITLE
Add discovery functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ dist/**/*
 # ignore yarn.lock
 yarn.lock
 
+# Homebridge runtime data
+examples/persist
+examples/accessories
+

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Only the `host` key is mandatory under devices. As password `''` is assumed aka 
 port number 6053 is also wired into the plugin. You can add, in theory, as many ESP devices as you want to
 that array.
 
+If some of your devices are password-less you can enable devices discovery to let the plugin find all your
+devices by setting `discover: true` in platform configuration. In case if you don't have any password-secured
+devices you can even fully omit `"devices"` section in platform configuration.
+
 In case you don't have a working esphome configuration you can have look at the examples folder. There you will
 find both an example homebridge `config.json` file as well as an example esphome configuration. For further guidance
 on esphome please check out their website.

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,17 @@
                 "title": "Debug",
                 "type": "boolean",
                 "required": false
+            },
+            "discover": {
+                "title": "Discover devices",
+                "type": "boolean",
+                "required": false
+            },
+            "discoveryTimeout": {
+                "title": "Discovery timeout",
+                "type": "integer",
+                "minimum": 0,
+                "required": false
             }
         }
     },
@@ -52,6 +63,7 @@
                 }
             ]
         },
-        "debug"
+        "debug",
+        "discover"
     ]
 }

--- a/examples/config.json
+++ b/examples/config.json
@@ -15,7 +15,9 @@
                 {
                     "host": "my_esp.local"
                 }
-            ]
+            ],
+            "discover": true,
+            "discoveryTimeout": 6000
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
             },
             "devDependencies": {
                 "@types/color-convert": "2.0.0",
+                "@types/ip": "1.1.0",
                 "@types/node": "14.14.37",
                 "@typescript-eslint/eslint-plugin": "4.22.1",
                 "@typescript-eslint/parser": "4.22.0",
@@ -109,9 +110,9 @@
             }
         },
         "node_modules/@homebridge/ciao/node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
             "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -224,6 +225,15 @@
             "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
             "dev": true
         },
+        "node_modules/@types/ip": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz",
+            "integrity": "sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -244,7 +254,8 @@
         "node_modules/@types/node": {
             "version": "14.14.37",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "4.22.1",
@@ -800,9 +811,9 @@
             }
         },
         "node_modules/chalk": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
             "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -810,6 +821,9 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/chalk/node_modules/ansi-styles": {
@@ -1352,39 +1366,18 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
             "dev": true,
             "engines": {
                 "node": ">=10"
             }
         },
-        "node_modules/eslint/node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/eslint/node_modules/globals": {
-            "version": "13.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
-            "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+            "version": "13.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+            "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -1446,21 +1439,21 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
-            "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
             "dependencies": {
-                "estraverse": "^5.0.0"
+                "estraverse": "^5.1.0"
             },
             "engines": {
-                "node": ">=8.0"
+                "node": ">=0.10"
             }
         },
         "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-            "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
             "dev": true,
             "engines": {
                 "node": ">=4.0"
@@ -1776,9 +1769,9 @@
             }
         },
         "node_modules/hap-nodejs/node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+            "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
             "dev": true
         },
         "node_modules/has": {
@@ -2753,9 +2746,9 @@
             }
         },
         "node_modules/prettier-eslint/node_modules/typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -2820,6 +2813,11 @@
                 "pbjs": "bin/pbjs",
                 "pbts": "bin/pbts"
             }
+        },
+        "node_modules/protobufjs/node_modules/@types/node": {
+            "version": "13.13.52",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+            "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -3002,13 +3000,11 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
             "integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
             "dependencies": {
-                "tslib": "~2.1.0"
+                "tslib": "^1.9.0"
+            },
+            "engines": {
+                "npm": ">=2.0.0"
             }
-        },
-        "node_modules/rxjs/node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -3017,9 +3013,9 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -3256,15 +3252,19 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.0.tgz",
-            "integrity": "sha512-51Na3IUg3uOACsQ7hzTUCjSzGy8xROySgI8tmNJ+y9JF2hfDS6qkTP7+Ep3htUtSQG1t17QMbe+jZFTlaU4dDQ==",
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+            "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
                 "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/table/node_modules/json-schema-traverse": {
@@ -3310,10 +3310,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-            "dev": true
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/tsutils": {
             "version": "3.17.1",
@@ -3582,9 +3581,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+                    "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
                     "dev": true
                 }
             }
@@ -3690,6 +3689,15 @@
             "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
             "dev": true
         },
+        "@types/ip": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz",
+            "integrity": "sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -3710,7 +3718,8 @@
         "@types/node": {
             "version": "14.14.37",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+            "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "4.22.1",
@@ -4094,9 +4103,9 @@
             "dev": true
         },
         "chalk": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
@@ -4407,30 +4416,15 @@
             },
             "dependencies": {
                 "eslint-visitor-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-                    "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
-                    "dev": true
-                },
-                "esquery": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-                    "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-                    "dev": true,
-                    "requires": {
-                        "estraverse": "^5.1.0"
-                    }
-                },
-                "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
                     "dev": true
                 },
                 "globals": {
-                    "version": "13.7.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
-                    "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+                    "version": "13.9.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+                    "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
                     "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
@@ -4621,18 +4615,18 @@
             "dev": true
         },
         "esquery": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
-            "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
             "requires": {
-                "estraverse": "^5.0.0"
+                "estraverse": "^5.1.0"
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-                    "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
                     "dev": true
                 }
             }
@@ -4894,9 +4888,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+                    "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
                     "dev": true
                 }
             }
@@ -5675,9 +5669,9 @@
                     }
                 },
                 "typescript": {
-                    "version": "3.9.7",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-                    "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+                    "version": "3.9.9",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+                    "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
                     "dev": true
                 }
             }
@@ -5725,6 +5719,13 @@
                 "@types/long": "^4.0.1",
                 "@types/node": ">=13.7.0",
                 "long": "^4.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "13.13.52",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+                    "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+                }
             }
         },
         "punycode": {
@@ -5845,14 +5846,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
             "integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
             "requires": {
-                "tslib": "~2.1.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-                }
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -5862,9 +5856,9 @@
             "dev": true
         },
         "semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -6060,9 +6054,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.0.tgz",
-                    "integrity": "sha512-51Na3IUg3uOACsQ7hzTUCjSzGy8xROySgI8tmNJ+y9JF2hfDS6qkTP7+Ep3htUtSQG1t17QMbe+jZFTlaU4dDQ==",
+                    "version": "7.2.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+                    "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -6113,10 +6107,9 @@
             }
         },
         "tslib": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-            "dev": true
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "tsutils": {
             "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "devDependencies": {
         "@types/color-convert": "2.0.0",
+        "@types/ip": "1.1.0",
         "@types/node": "14.14.37",
         "@typescript-eslint/eslint-plugin": "4.22.1",
         "@typescript-eslint/parser": "4.22.0",

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,0 +1,40 @@
+import Bonjour, { BonjourFindOptions, BonjourService } from 'bonjour-hap';
+import ip from 'ip';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+const debug = require('debug')('homebridgeEsphomeTs');
+const bonjour = new Bonjour();
+
+const DEFAULT_PORT = 6053;
+
+type DiscoveryResult = {
+    host: string;
+    port?: number;
+    address?: string;
+};
+
+export function discoverDevices(timeout: number): Observable<DiscoveryResult> {
+    return new Observable<BonjourService>((subscriber) => {
+        const browser = bonjour.find({ type: 'esphomelib' }, (service) => {
+            subscriber.next(service);
+        });
+        setTimeout(() => {
+            browser.stop();
+            subscriber.complete();
+        }, timeout);
+    }).pipe(
+        map((findResult: BonjourService) => {
+            debug('HAP Device discovered', findResult.name);
+            const address = findResult.addresses.find((addr) => {
+                return (ip.isV4Format(addr) && addr.substring(0, 7) !== '169.254') || ip.isV6Format(addr);
+            });
+            const port = findResult.port && findResult.port !== DEFAULT_PORT ? findResult.port : undefined;
+            return {
+                host: findResult.host,
+                port,
+                address,
+            };
+        }),
+    );
+}

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,20 +1,20 @@
-import Bonjour, { BonjourFindOptions, BonjourService } from 'bonjour-hap';
+import Bonjour, { BonjourService } from 'bonjour-hap';
+import { Logging } from 'homebridge';
 import ip from 'ip';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-const debug = require('debug')('homebridgeEsphomeTs');
 const bonjour = new Bonjour();
 
 const DEFAULT_PORT = 6053;
 
-type DiscoveryResult = {
+interface DiscoveryResult {
     host: string;
     port?: number;
     address?: string;
-};
+}
 
-export function discoverDevices(timeout: number): Observable<DiscoveryResult> {
+export const discoverDevices = (timeout: number, log: Logging): Observable<DiscoveryResult> => {
     return new Observable<BonjourService>((subscriber) => {
         const browser = bonjour.find({ type: 'esphomelib' }, (service) => {
             subscriber.next(service);
@@ -25,7 +25,7 @@ export function discoverDevices(timeout: number): Observable<DiscoveryResult> {
         }, timeout);
     }).pipe(
         map((findResult: BonjourService) => {
-            debug('HAP Device discovered', findResult.name);
+            log.info('HAP Device discovered', findResult.name);
             const address = findResult.addresses.find((addr) => {
                 return (ip.isV4Format(addr) && addr.substring(0, 7) !== '169.254') || ip.isV6Format(addr);
             });
@@ -37,4 +37,4 @@ export function discoverDevices(timeout: number): Observable<DiscoveryResult> {
             };
         }),
     );
-}
+};

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,24 +1,30 @@
 import { API, DynamicPlatformPlugin, Logging, PlatformAccessory, PlatformConfig } from 'homebridge';
-import { interval, of, Subscription } from 'rxjs';
-import { catchError, filter, take, tap, timeout } from 'rxjs/operators';
+import { concat, from, interval, Observable, of, Subscription } from 'rxjs';
+import { catchError, filter, map, take, tap, timeout } from 'rxjs/operators';
 import { componentHelpers } from './homebridgeAccessories/componentHelpers';
 import { Accessory, PLATFORM_NAME, PLUGIN_NAME, UUIDGen } from './index';
-import { BaseComponent, EspDevice } from 'esphome-ts';
-import { isRecord, writeReadDataToLogFile } from './shared';
+import { writeReadDataToLogFile } from './shared';
+import { EspDevice } from 'esphome-ts';
+import { discoverDevices } from './discovery';
 
-interface IEsphomePlatformConfig extends PlatformConfig {
-    devices?: {
-        host: string;
-        password?: string;
-        port?: number;
-        retryAfter?: number;
-    }[];
-    blacklist?: string[];
-    debug?: boolean;
+interface IEsphomeDeviceConfig {
+    host: string;
+    port?: number;
+    password?: string;
     retryAfter?: number;
 }
 
+interface IEsphomePlatformConfig extends PlatformConfig {
+    devices?: IEsphomeDeviceConfig[];
+    blacklist?: string[];
+    debug?: boolean;
+    retryAfter?: number;
+    discover?: boolean;
+    discoveryTimeout?: number;
+}
+
 const DEFAULT_RETRY_AFTER = 90 * 1000;
+const DEFAULT_DISCOVERY_TIMEOUT = 5 * 1000; // milliseconds
 
 export class EsphomePlatform implements DynamicPlatformPlugin {
     protected readonly espDevices: EspDevice[] = [];
@@ -33,8 +39,11 @@ export class EsphomePlatform implements DynamicPlatformPlugin {
     ) {
         this.subscription = new Subscription();
         this.log('starting esphome');
-        if (!Array.isArray(this.config.devices)) {
-            this.log.error('You did not specify a devices array! Esphome will not provide any accessories');
+        if (!Array.isArray(this.config.devices) && !this.config.discover) {
+            this.log.error(
+                'You did not specify a devices array and discovery is ' +
+                'disabled! Esphome will not provide any accessories',
+            );
             this.config.devices = [];
         }
         this.blacklistSet = new Set<string>(this.config.blacklist ?? []);
@@ -49,7 +58,33 @@ export class EsphomePlatform implements DynamicPlatformPlugin {
     }
 
     protected onHomebridgeDidFinishLaunching(): void {
-        this.config.devices?.forEach((deviceConfig) => {
+        let devices: Observable<IEsphomeDeviceConfig> = from(this.config.devices ?? []);
+        if (this.config.discover) {
+            const excludeConfigDevices: Set<string> = new Set();
+            devices = concat(
+                discoverDevices(this.config.discoveryTimeout ?? DEFAULT_DISCOVERY_TIMEOUT).pipe(
+                    map((discoveredDevice) => {
+                        const configDevice = this.config.devices?.find(({ host }) => host === discoveredDevice.host);
+                        let deviceConfig = discoveredDevice;
+                        if (configDevice) {
+                            excludeConfigDevices.add(configDevice.host);
+                            deviceConfig = { ...discoveredDevice, ...configDevice };
+                        }
+
+                        return {
+                            ...deviceConfig,
+                            // Override hostname with ip address when available
+                            // to avoid issues with mDNS resolution at OS level
+                            host: discoveredDevice.address ?? discoveredDevice.host,
+                        };
+                    }),
+                ),
+                // Feed into output remaining devices from config that haven't been discovered
+                devices.pipe(filter(({ host }) => !excludeConfigDevices.has(host))),
+            );
+        }
+
+        devices.forEach((deviceConfig) => {
             const device = new EspDevice(deviceConfig.host, deviceConfig.password, deviceConfig.port);
             if (this.config.debug) {
                 this.log('Writing the raw data from your ESP Device to /tmp');

--- a/src/types/bonjour-hap/index.d.ts
+++ b/src/types/bonjour-hap/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'bonjour-hap' {
+    export type BonjourFindOptions = {};
+
+    export type BonjourService = {
+        name: string;
+        host: string;
+        port?: number;
+        addresses: string[];
+    };
+
+    export class Browser {
+        stop(): void;
+    }
+
+    export default class Bonjour {
+        find(options: BonjourFindOptions, onUp: (service: BonjourService) => void): Browser;
+    }
+}


### PR DESCRIPTION
Discovery is implemented using `bonjour-hap` pure-JS client library and apart from avoid enumerating all devices in config also helps connecting to devices by replacing hostname with ip address as some Homebridge distributions might have issues with mDNS discovery (I'm looking at you, homebridge:alpine image)